### PR TITLE
Update OMTG_DATAST_001_SharedPreferences.java to run on API > 17

### DIFF
--- a/Android/MSTG-Android-Java-App/app/src/main/java/sg/vp/owasp_mobile/OMTG_Android/OMTG_DATAST_001_SharedPreferences.java
+++ b/Android/MSTG-Android-Java-App/app/src/main/java/sg/vp/owasp_mobile/OMTG_Android/OMTG_DATAST_001_SharedPreferences.java
@@ -18,7 +18,7 @@ public class OMTG_DATAST_001_SharedPreferences extends AppCompatActivity {
 
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        SharedPreferences sharedPref = getSharedPreferences("key", MODE_WORLD_READABLE);
+        SharedPreferences sharedPref = getSharedPreferences("key", MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPref.edit();
         editor.putString("username", "administrator");
         editor.putString("password", "supersecret");


### PR DESCRIPTION
MODE_WORLD_READABLE (Constant value 0x00000001) was deprecated in API Level 17. Shared Preferences functionality crashes the app.
Editing the value to MODE_PRIVATE (Constant value 0x00000000) fixes the issue.